### PR TITLE
chore(a): actualizar devDependencies (TypeScript, Jest) y agregar scaffold TS

### DIFF
--- a/api-server/package.json
+++ b/api-server/package.json
@@ -25,8 +25,8 @@
   },
   "devDependencies": {
     "nodemon": "^3.0.1",
-    "jest": "^29.5.0",
-    "supertest": "^6.3.3"
+    "jest": "^29.7.0",
+    "supertest": "^6.3.4"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -151,9 +151,9 @@
     "watch": "tsc -watch -p ./"
   },
   "devDependencies": {
-    "@types/vscode": "^1.74.0",
-    "@types/node": "^18.x",
-    "typescript": "^4.9.4"
+    "@types/vscode": "^1.81.0",
+    "@types/node": "^20.0.0",
+    "typescript": "^5.3.3"
   },
   "dependencies": {
     "axios": "^1.4.0"

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1,0 +1,10 @@
+import * as vscode from 'vscode';
+
+export function activate(context: vscode.ExtensionContext) {
+  const disposable = vscode.commands.registerCommand('homebrew-cli-guide.openGuide', () => {
+    vscode.window.showInformationMessage('Homebrew CLI Guide: Open Guide command (placeholder)');
+  });
+  context.subscriptions.push(disposable);
+}
+
+export function deactivate() {}

--- a/vscode-extension/tsconfig.json
+++ b/vscode-extension/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2020",
+    "outDir": "out",
+    "lib": ["es2020"],
+    "sourceMap": true,
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
Resumen:\n- Actualiza devDependencies principales: TypeScript en la extensión, Jest en api-server, @types actualizados.\n- Añade un tsconfig.json y un archivo mínimo src/extension.ts en vscode-extension para validar la compilación.\n\nPruebas realizadas localmente:\n- api-server: npm install y tests (jest --passWithNoTests) => OK\n- vscode-extension: npm install y npm run compile => OK (compilación TypeScript validada)\n\nPR objetivo: chore/update/placeholders-engines-2025-09-30 (merge a la rama de trabajo)