### PR TITLE
chore(c): intentar render PDF con Quarto en CI y fallback de sanitización

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,3 +93,31 @@ jobs:
         with:
           name: rendered-book
           path: _book
+
+  quarto-pdf:
+    name: Quarto PDF (attempt)
+    runs-on: ubuntu-latest
+    needs: quarto-render
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Quarto and try PDF render
+        uses: quarto-dev/quarto-actions@v2
+        with:
+          command: render
+          args: --no-execute --to pdf
+        continue-on-error: true
+
+      - name: Fallback: sanitize and re-render if previous step failed
+        if: failure()
+        run: |
+          chmod +x ./scripts/sanitize-quarto-for-latex.sh
+          ./scripts/sanitize-quarto-for-latex.sh
+
+      - name: Upload PDF artifact (if produced)
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rendered-pdf
+          path: _book

--- a/scripts/sanitize-quarto-for-latex.sh
+++ b/scripts/sanitize-quarto-for-latex.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(pwd)"
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+echo "Creating sanitized copy in $TMPDIR"
+# Copy only QMD and supporting metadata to tmpdir
+mkdir -p "$TMPDIR"
+rsync -a --include='*/' --include='*.qmd' --include='*.yml' --include='*.yaml' --include='*.bib' --exclude='*' "$REPO_ROOT/" "$TMPDIR/"
+
+# Replace common emoji and special unicode that breaks LaTeX
+# Add mappings here as needed (hex codepoints)
+perl -CSD -pe '\
+    s/\x{1F4DD}/[NOTE]/g; # 📝
+    s/\x{1F4D6}/[BOOK]/g; # 📖
+    s/\x{1F4D1}/[MARK]/g; # 📑
+' -i $(find "$TMPDIR" -name '*.qmd')
+
+# Render PDF in tmpdir
+cd "$TMPDIR"
+quarto render --to pdf --no-execute
+
+# Move artifacts back if successful (only _book/pdf)
+if [ -d "_book" ]; then
+  echo "Copying generated _book back to repository"
+  rsync -a _book "$REPO_ROOT/"
+fi
+
+echo "Sanitized Quarto PDF render completed." 


### PR DESCRIPTION
Resumen:\n- Añade script  que sanitiza contenido (.qmd) reemplazando emojis problemáticos para LaTeX, renderiza PDF y copia artefactos.\n- Agrega job  en el workflow CI que intenta render a PDF. Si falla, ejecuta el script de sanitización y reintenta.\n\nPruebas locales:\n- Intenté  localmente y falló por caracteres Unicode. La sanitización en local (usando el script) permite un re-render que genera  y produce PDFs en un entorno con TeX instalado.\n\nPR objetivo: chore/update/placeholders-engines-2025-09-30