### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Codeowners for main areas
+# Use GitHub usernames (without @)
+
+/vscode-extension/ laguileracl
+/api-server/ laguileracl
+/docs/ laguileracl
+/*.md laguileracl


### PR DESCRIPTION
Añade archivo .github/CODEOWNERS para asignar responsabilidad sobre la extensión VS Code, el API y la documentación al mantenedor principal.